### PR TITLE
Update hashparser.js

### DIFF
--- a/src/hashparser.js
+++ b/src/hashparser.js
@@ -3,7 +3,8 @@ export default class HashParser {
 
     constructor({encoded = false} = {}) {
         this._encoded = encoded;
-        this.params = new URLSearchParams(window.location.hash.replace(/^#/g, ''));
+        this._readhash()
+        window.addEventListener('hashchange', this._readhash, false);
     }
 
     static get encoded() {
@@ -22,6 +23,10 @@ export default class HashParser {
 
     _decode(value) {
         return JSON.parse(atob(value));
+    }
+
+    _readhash() {
+        this.params = new URLSearchParams(window.location.hash.replace(/^#/g, ''));
     }
 
     get(key, defaultValue) {


### PR DESCRIPTION
Changes to the hash not done by the hash parser itself are not seen by hash parser. 

To reproduce the issue. Just go to a page with the hash parser installed and add "&foo-bar" to the hash of the page and then execute hashparser.has("foo"). It will return false.

With this changes it keeps track of all changes applied and the get and has functions will always return the current state of the hash

