### PR TITLE
Keep HashParse in sync with the page's hash at all times

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,17 @@ hp.set('foo', 'bar'); // example.com#foo=ImJhciI%3D
 hp.get('foo'); // "bar"
 ```
 
+## Options
+
+The following options can be passed to a new HashParser instance:
+
+```js
+{
+  encoded: false, // default value is false, set to true to always encode values
+  sync: true // default value is true, this will listen for hashchange events on the window object and update the internal dataset.
+}
+```
+
 ### Building
 
 Compile the source files to the `dist` folder:

--- a/src/hashparser.js
+++ b/src/hashparser.js
@@ -2,10 +2,11 @@ export default class HashParser {
     _encoded;
 
     constructor({ encoded = false, sync = true } = {}) {
-        let that = this;
         this._encoded = encoded;
         this._readHash()
-        if(sync) window.addEventListener('hashchange', ()=>{that._readHash()}, false);
+        if (sync) {
+            window.addEventListener('hashchange', () => this._readHash(), false);
+        }
     }
 
     static get encoded() {

--- a/src/hashparser.js
+++ b/src/hashparser.js
@@ -3,7 +3,8 @@ export default class HashParser {
 
     constructor({encoded = false} = {}) {
         this._encoded = encoded;
-        this.params = new URLSearchParams(window.location.hash.replace(/^#/g, ''));
+        this._readhash()
+        window.addEventListener('hashchange', this._readhash, false);
     }
 
     static get encoded() {
@@ -22,6 +23,10 @@ export default class HashParser {
 
     _decode(value) {
         return JSON.parse(atob(value));
+    }
+
+    _readhash() {
+        this.params = new URLSearchParams(window.location.hash.replace(/^#/g, ''));
     }
 
     get(key, defaultValue) {

--- a/src/hashparser.js
+++ b/src/hashparser.js
@@ -1,10 +1,11 @@
 export default class HashParser {
     _encoded;
 
-    constructor({encoded = false} = {}) {
+    constructor({ encoded = false, sync = true } = {}) {
+        let that = this;
         this._encoded = encoded;
-        this._readhash()
-        window.addEventListener('hashchange', this._readhash, false);
+        this._readHash()
+        if(sync) window.addEventListener('hashchange', ()=>{that._readHash()}, false);
     }
 
     static get encoded() {
@@ -25,7 +26,7 @@ export default class HashParser {
         return JSON.parse(atob(value));
     }
 
-    _readhash() {
+    _readHash() {
         this.params = new URLSearchParams(window.location.hash.replace(/^#/g, ''));
     }
 

--- a/src/hashparser.js
+++ b/src/hashparser.js
@@ -72,4 +72,4 @@ export default class HashParser {
 
         window.location.hash = `#${this.params.toString()}`;
     }
-}
+} 


### PR DESCRIPTION
HashParser will now update its parameters object when a 'hashchange' event is fired by the browser. This ensures that  HashParser stays in sync with the documents hash at all times.